### PR TITLE
add remote sync options

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14,13 +14,35 @@ function plugin(plugin) {
 	_pouchdb2.default.plugin(plugin);
 }
 
+function syncRemote(localDB, sync) {
+	if (!sync.db) throw new Error('vuejs sync → error → please set remote db name!');
+
+	var options = sync.options || {};
+
+	var onChange = sync.onChange || function () {};
+	var onPaused = sync.onPaused || function () {};
+	var onActive = sync.onActive || function () {};
+	var onError = sync.onError || function () {};
+
+	return localDB.sync(sync.db, options).on('change', onChange).on('paused', onPaused).on('active', onActive).on('error', onError);
+}
+
 function install(Vue) {
 	var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
 	if (!options.name) throw new Error('vuejs-pouchdb → error → please set db name!');
-	dbName = options.name;
+
+	var dbName = options.name;
+	var sync = options.sync;
+
 	delete options.name;
 	var db = new _pouchdb2.default(dbName, options);
+
+	if (sync) {
+		delete options.sync;
+		Vue.pouchSyncHandler = syncRemote(db, sync);
+		Vue.prototype.$pouchSyncHandler = Vue.pouchSyncHandler;
+	}
 
 	Vue.pouch = db;
 	Vue.prototype.$pouch = db;

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,37 @@ function plugin (plugin) {
 	pouchdb.plugin(plugin)
 }
 
+function syncRemote(localDB, sync) {
+	if(!sync.db) throw new Error('vuejs sync → error → please set remote db name!')
+
+	let options = sync.options || {}
+
+	let onChange = sync.onChange || function() {}
+	let onPaused = sync.onPaused || function() {}
+	let onActive = sync.onActive || function() {}
+	let onError  = sync.onError  || function() {}
+
+	return localDB.sync(sync.db, options).
+					 on('change', onChange).
+					 on('paused', onPaused).
+					 on('active', onActive).
+					 on('error', onError)
+}
+
 function install (Vue, options = {}) {
 	if(!options.name) throw new Error('vuejs-pouchdb → error → please set db name!')
+
 	let dbName = options.name
+	let sync = options.sync
+
 	delete options.name
 	let db = new pouchdb(dbName, options)
+
+	if(sync) {
+		delete options.sync
+		Vue.pouchSyncHandler = syncRemote(db, sync)
+		Vue.prototype.$pouchSyncHandler = Vue.pouchSyncHandler
+	}
 
 	Vue.pouch = db
 	Vue.prototype.$pouch = db


### PR DESCRIPTION
This PR adds the ability to add a `sync` option to the PouchDB component.

For this you will need a sync object formed like:

```
Vue.use(VuePouchDB, { name: "localDB",
  skip_setup: true,
  sync: {
    db: "remoteDB",
    options: { live: true },
    onChange (data) {
      console.log(data)
    },
    onPaused (data) {
      console.log(data)
    },
    onActive (data) {
      console.log(data)
    },
    onError (error) {
      console.log(error)
    },
  }
})
```

This will set a sync (bidirectional replication) between remote and local DB.

There is a `pouchSyncHandler` prop added to `Vue`,  so you can use complete, and other PouchDB native events.